### PR TITLE
test

### DIFF
--- a/write_fit.py
+++ b/write_fit.py
@@ -6,13 +6,14 @@ import struct
 import datetime
 import iso8601
 import time
+import pytz
 import binascii
 import math
 from xml.dom.minidom import parse
 import xml.etree.ElementTree as ET
 
 # Garmin-defined
-epoch = datetime.datetime(1989, 12, 31, 0, 0, 0)
+epoch = datetime.datetime(1989, 12, 31, 0, 0, 0, tzinfo=pytz.UTC)
 
 track_name = ""
 laps = []
@@ -171,7 +172,7 @@ out.write(write_field(0, [
     (1, "uint16", 1), # manufacturer
     (2, "uint16", 1), # product
     (3, "uint32z", 1), # serial
-    (4, "uint32", int((datetime.datetime.utcnow() - epoch).total_seconds())) # time_created
+    (4, "uint32", int((datetime.datetime.now(tz=pytz.UTC) - epoch).total_seconds())) # time_created
         ]))
 
 # 31, course

--- a/write_fit.py
+++ b/write_fit.py
@@ -4,6 +4,7 @@
 import sys
 import struct
 import datetime
+import iso8601
 import time
 import binascii
 import math
@@ -38,12 +39,7 @@ def step_tcx(data):
     # Lap start _time_ needs to be logged... same as the timestamp?
     def track_point(node):
         time_raw = node.find("Time").text
-        # Garmin Connect  includes .%f, RideWithGPS doesn't.
-        if '.' in time_raw:
-            format = "%Y-%m-%dT%H:%M:%S.%fZ"
-        else:
-            format = "%Y-%m-%dT%H:%M:%S"
-        time = datetime.datetime.strptime(time_raw, format)
+        time = iso8601.parse_date(time_raw)
         etime = time - epoch
         distance = int(float(node.find("DistanceMeters").text)*100)
         # Should probably XPath this


### PR DESCRIPTION
### Description
This pull request introduces changes to improve date and time handling in the `write_fit.py` script. The main modifications include:

1. Adding `iso8601` and `pytz` libraries to handle ISO 8601 date formats and timezone-aware datetime objects.
2. Replacing the custom datetime parsing logic with `iso8601.parse_date()` function to handle various ISO 8601 date format variations.
3. Making the `epoch` datetime object timezone-aware by adding `tzinfo=pytz.UTC`.
4. Updating the `time_created` calculation to use a timezone-aware `datetime.now()`.

These changes aim to enhance the robustness of date parsing and ensure consistent timezone handling throughout the script.

### Changes that Break Backward Compatibility
N/A

### Documentation
N/A

*Created with [Palmier](https://www.palmier.io)*